### PR TITLE
Bump version to 1.1.0 and add .NET Standard 2.0 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Commands
+
+### Build and Test
+```bash
+dotnet build                                    # Build the solution
+dotnet test                                     # Run all tests
+dotnet test --logger "console;verbosity=detailed"  # Run tests with detailed output
+dotnet pack                                     # Create NuGet packages
+```
+
+### Development Workflow
+```bash
+dotnet build LayeredCraft.StructuredLogging.sln  # Build entire solution
+dotnet test test/LayeredCraft.StructuredLogging.Tests/  # Run specific test project
+dotnet run --project test/LayeredCraft.StructuredLogging.Tests/  # Run test project directly
+```
+
+## Project Architecture
+
+### Core Structure
+- **src/LayeredCraft.StructuredLogging/** - Main library containing all logging extensions
+- **test/LayeredCraft.StructuredLogging.Tests/** - Comprehensive test suite with xUnit3, AutoFixture, and NSubstitute
+
+### Key Components
+- **LoggerExtensionsBase.cs** - Internal base class providing optimized logging methods with level checks
+- **Extension Classes** - Individual files for each log level (Debug, Information, Warning, Error, Critical, Verbose)
+- **Specialized Extensions**:
+  - **ScopeExtensions.cs** - Scope management and timed operations
+  - **EnrichmentExtensions.cs** - Contextual logging with UserId, RequestId, CorrelationId
+  - **PerformanceExtensions.cs** - Performance monitoring and timing utilities
+  - **Testing/TestingExtensions.cs** - Testing framework with TestLogger and assertions
+
+### Target Frameworks
+- Multi-target: .NET 8.0, .NET 9.0, .NET Standard 2.1, .NET Standard 2.0
+- Uses modern C# features with nullable reference types enabled
+
+### Dependencies
+- **Microsoft.Extensions.Logging.Abstractions** - Core logging abstraction
+- **Test Dependencies**: xUnit3, AutoFixture, NSubstitute, AwesomeAssertions
+
+## Development Guidelines
+
+### Code Organization
+- Each log level has its own extension class (e.g., `InformationExtensions.cs`)
+- All extensions use the internal `LoggerExtensionsBase` for performance-optimized logging
+- Performance checks (`logger.IsEnabled(logLevel)`) are built into base methods
+- Comprehensive XML documentation is required for all public APIs
+
+### Testing Strategy
+- Test project uses xUnit3 with AutoFixture for test data generation
+- NSubstitute for mocking ILogger instances
+- AwesomeAssertions for fluent test assertions
+- TestLogger framework provides specialized logging test utilities
+- Tests are organized by feature area matching the main library structure
+
+### Package Configuration
+- NuGet package metadata is defined in the main project file
+- Version is controlled via Directory.Build.props (currently 1.1.0)
+- Package includes icon.png and README.md
+- Source linking and symbol packages are enabled for debugging
+
+### CI/CD Integration
+- GitHub Actions workflow uses LayeredCraft shared templates
+- Builds on .NET 8.0 and 9.0
+- Automated package building and publishing on tags/releases

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionPrefix>1.1.0</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/src/LayeredCraft.StructuredLogging/LayeredCraft.StructuredLogging.csproj
+++ b/src/LayeredCraft.StructuredLogging/LayeredCraft.StructuredLogging.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net8.0;net9.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
 
         <!-- Package metadata -->
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0 to 1.1.0 in Directory.Build.props
- Add .NET Standard 2.0 support to target frameworks alongside existing net8.0, net9.0, and netstandard2.1
- Add CLAUDE.md documentation for future development guidance

## Changes Made
- **Directory.Build.props**: Updated `<VersionPrefix>` from 1.0.0 to 1.1.0
- **LayeredCraft.StructuredLogging.csproj**: Added `netstandard2.0` to `<TargetFrameworks>`
- **CLAUDE.md**: Added comprehensive development documentation

## Compatibility Verification
- ✅ Microsoft.Extensions.Logging.Abstractions 9.0.7 supports .NET Standard 2.0
- ✅ Project builds successfully for all target frameworks (net8.0, net9.0, netstandard2.1, netstandard2.0)
- ✅ All 328 tests pass on both .NET 8.0 and .NET 9.0 frameworks

## Test Results
- **NET 8.0**: 328 tests passed, 0 failures, 0 errors
- **NET 9.0**: 328 tests passed, 0 failures, 0 errors

## Breaking Changes
None - this is a backward-compatible addition of .NET Standard 2.0 support.

🤖 Generated with [Claude Code](https://claude.ai/code)