### PR TITLE
Update NuGet packages and bump version to 1.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.1.0</VersionPrefix>
+        <VersionPrefix>1.1.1</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/src/LayeredCraft.StructuredLogging/LayeredCraft.StructuredLogging.csproj
+++ b/src/LayeredCraft.StructuredLogging/LayeredCraft.StructuredLogging.csproj
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 

--- a/test/LayeredCraft.StructuredLogging.Tests/LayeredCraft.StructuredLogging.Tests.csproj
+++ b/test/LayeredCraft.StructuredLogging.Tests/LayeredCraft.StructuredLogging.Tests.csproj
@@ -26,11 +26,11 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
         <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0"/>
-        <PackageReference Include="AwesomeAssertions" Version="9.0.0"/>
+        <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="xunit.v3" Version="2.0.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+        <PackageReference Include="xunit.v3" Version="3.0.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary
- Updated Microsoft.Extensions.Logging.Abstractions from 9.0.7 to 9.0.8
- Updated AwesomeAssertions from 9.0.0 to 9.1.0  
- Updated xunit.v3 from 2.0.3 to 3.0.1
- Updated xunit.runner.visualstudio from 3.1.1 to 3.1.4
- Bumped package version from 1.1.0 to 1.1.1

## Test plan
- [x] All 328 tests pass on .NET 8.0 framework
- [x] All 328 tests pass on .NET 9.0 framework
- [x] Package builds successfully with updated dependencies
- [x] No breaking changes or regressions introduced

🤖 Generated with [Claude Code](https://claude.ai/code)