### PR TITLE
chore(deps): bump package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,23 +6,23 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.3.26207.106" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.4.26230.115" />
   </ItemGroup>
   <ItemGroup Label="GitHub">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" PrivateAssets="All" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Bump NuGet package versions across all target frameworks in `Directory.Packages.props`.

| Package | Old | New |
|---|---|---|
| `Microsoft.Extensions.Logging.Abstractions` (net9.0) | 9.0.15 | 9.0.16 |
| `Microsoft.Extensions.Logging.Abstractions` (net10.0) | 10.0.6 | 10.0.8 |
| `Microsoft.Extensions.Logging.Abstractions` (net11.0) | preview.3.26207.106 | preview.4.26230.115 |
| `Microsoft.SourceLink.GitHub` | 10.0.202 | 10.0.300 |
| `Microsoft.NET.Test.Sdk` | 18.4.0 | 18.5.1 |

---

## ✅ Checklist

- [ ] My changes build cleanly
- [ ] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [ ] I've followed the coding style for this project
- [ ] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #...

---

## 💬 Notes for Reviewers

Routine dependency maintenance. No API changes.