### PR TITLE
chore(deps): bump package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,13 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.17" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.5.26302.115" />
   </ItemGroup>
   <ItemGroup Label="GitHub">
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## 📋 Summary

Bumps dependency versions in `Directory.Packages.props` to keep target-framework-specific logging abstractions and test tooling current. This updates the .NET 9, .NET 10, and .NET 11 preview `Microsoft.Extensions.Logging.Abstractions` package versions along with `Microsoft.NET.Test.Sdk`.

## 📝 Changes

- Updated `Microsoft.Extensions.Logging.Abstractions` for `net9.0`, `net10.0`, and `net11.0` targets.
- Updated `Microsoft.NET.Test.Sdk` from `18.5.1` to `18.7.0`.

## 🧪 Validation

- `dotnet test` passed: 1312 succeeded, 0 failed, 0 skipped.
- Existing nullable warnings were emitted during build/test.

## 📦 Release Notes

- Dependency versions refreshed for package build and test infrastructure.
