### PR TITLE
ci: upgrade devops-templates to v10.0 with NuGet trusted publishing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches:
       - main
-permissions:
-  contents: read
+permissions: write-all
 jobs:
   build:
     uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches:
       - main
-permissions: write-all
+permissions:
+  contents: read
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.0
     with:
       solution: LayeredCraft.StructuredLogging.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v10.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -6,11 +6,13 @@ on:
     branches:
       - main
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.0
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.0
     with:
       solution: LayeredCraft.StructuredLogging.slnx
       dotnetVersion: |
@@ -20,3 +22,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -4,11 +4,12 @@ on:
   release:
     types: [published]
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.0
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.0
     with:
       solution: LayeredCraft.StructuredLogging.slnx
       dotnetVersion: |
@@ -18,3 +19,14 @@ jobs:
         11.0.x
       hasTests: true
     secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v10.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}


### PR DESCRIPTION
## Summary

Upgrades all workflow references from `devops-templates@v8.0` to `v10.0` and converts the publish flows to use NuGet Trusted Publishing (OIDC) via the new `nuget-push` composite action introduced in v10.0.

## Changes

**`publish-preview.yaml` and `publish-release.yaml`**
- Renamed `publish` job to `build` — now calls the shared template for version resolution, build, test, pack, and artifact upload only
- Added `push` job that uses `LayeredCraft/devops-templates/.github/actions/nuget-push@v10.0` to handle OIDC login and NuGet push
- Replaced `permissions: write-all` with least-privilege permissions per job

**`pr-build.yaml`**
- Updated to `@v10.0`
- Replaced `permissions: write-all` with `contents: read`

**`pr-title-check.yaml` and `release-drafter.yaml`**
- Updated to `@v10.0`

## Validation

- `publish-preview` flow validated end-to-end on `LayeredCraft/compact-json-formatter` with the same template version and composite action
- OIDC exchange succeeds because the `push` job runs in the caller's workflow context, making `job_workflow_ref` match the NuGet trusted publisher policy

## Notes for Reviewers

The key architectural reason for splitting build and push into separate jobs: GitHub's OIDC token includes a `job_workflow_ref` claim set to the workflow file where the job *physically runs*. When NuGet/login ran inside the shared reusable workflow, the claim pointed to `devops-templates` — which NuGet.org's trusted publisher policy rejected. Running the push in a composite action (which executes inline in the caller's job) keeps the claim pointed at this repo's workflow file.

NuGet.org trusted publisher policy for this repo will need to be configured to match `.github/workflows/publish-preview.yaml` and `.github/workflows/publish-release.yaml` before the push jobs will succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)